### PR TITLE
Require the connection lock earlier in iterate

### DIFF
--- a/src/quart_db/connection.py
+++ b/src/quart_db/connection.py
@@ -152,13 +152,13 @@ class Connection:
 
         """
         compiled_query, args = self._compile(query, values)
-        async with self._connection.transaction():
-            try:
-                async with self._lock:
+        async with self._lock:
+            async with self._connection.transaction():
+                try:
                     async for record in self._connection.cursor(compiled_query, *args):
                         yield record
-            except asyncpg.exceptions.UndefinedParameterError as error:
-                raise UndefinedParameterError(str(error))
+                except asyncpg.exceptions.UndefinedParameterError as error:
+                    raise UndefinedParameterError(str(error))
 
     def transaction(self, *, force_rollback: bool = False) -> "Transaction":
         """Open a transaction


### PR DESCRIPTION
Iterate requires starting a transaction which can error
with "operation already in progress" if another query
is being executed by a different task.

Iterate did acquire a lock before, this commit simply
moves it to before the transaction is started.