### PR TITLE
Acquire the connection lock on Transaction

### DIFF
--- a/src/quart_db/connection.py
+++ b/src/quart_db/connection.py
@@ -29,16 +29,19 @@ class Transaction:
             await self.commit()
 
     async def start(self) -> None:
-        self._transaction = self._connection._connection.transaction()
-        await self._transaction.start()
+        async with self._connection._lock:
+            self._transaction = self._connection._connection.transaction()
+            await self._transaction.start()
 
     async def commit(self) -> None:
-        await self._transaction.commit()
-        self._transaction = None
+        async with self._connection._lock:
+            await self._transaction.commit()
+            self._transaction = None
 
     async def rollback(self) -> None:
-        await self._transaction.rollback()
-        self._transaction = None
+        async with self._connection._lock:
+            await self._transaction.rollback()
+            self._transaction = None
 
 
 class Connection:


### PR DESCRIPTION
When a connection is shared across tasks interacting with a
transaction, i.e. start, commit, or rollback, will fail if
another task is executing a query with an "operation already
in progress error".

Acquire the connection lock before attempting to perform
these operations.