### PR TITLE
Update config docs

### DIFF
--- a/docs/how_to_guides/configuration.rst
+++ b/docs/how_to_guides/configuration.rst
@@ -18,7 +18,8 @@ QUART_DB_AUTO_REQUEST_CONNECTION bool
 is ``None`` by default (set via constructor argument).
 
 ``QUART_DB_MIGRATIONS_FOLDER`` refers to the location of the
-migrations folder relative to the app's root path.
+migrations folder relative to the app's root path. You can set
+this to `None` in order to disable the migrations system.
 
 ``QUART_DB_DATA_PATH`` refers to the location of the data module
 relative to the app's root path.


### PR DESCRIPTION
Added memo about optionally disabling migrations system by setting `QUART_DB_MIGRATIONS_FOLDER` to `None`