### PR TITLE
Avoid double-close if the pool has already been disconnected

### DIFF
--- a/src/quart_db/backends/asyncpg.py
+++ b/src/quart_db/backends/asyncpg.py
@@ -159,7 +159,8 @@ class Backend(BackendABC):
             self._pool = await asyncpg.create_pool(dsn=self._url, init=self._init)
 
     async def disconnect(self, timeout: Optional[int] = None) -> None:
-        await asyncio.wait_for(self._pool.close(), timeout)
+        if self._pool:
+            await asyncio.wait_for(self._pool.close(), timeout)
         self._pool = None
 
     async def acquire(self) -> Connection:

--- a/src/quart_db/backends/asyncpg.py
+++ b/src/quart_db/backends/asyncpg.py
@@ -159,7 +159,7 @@ class Backend(BackendABC):
             self._pool = await asyncpg.create_pool(dsn=self._url, init=self._init)
 
     async def disconnect(self, timeout: Optional[int] = None) -> None:
-        if self._pool:
+        if self._pool is not None:
             await asyncio.wait_for(self._pool.close(), timeout)
         self._pool = None
 


### PR DESCRIPTION
- `disconnect` should probably be idempotent

I ran into this issue when trying to juggle some test fixtures that weren't cleaning up after themselves properly. I'm reasonably sure that this was in our code, but this change still would have helped me.

Thanks for quart!