### PR TITLE
Threading through callable to support password rotation

### DIFF
--- a/src/quart_db/backends/aiosqlite.py
+++ b/src/quart_db/backends/aiosqlite.py
@@ -1,7 +1,7 @@
 import asyncio
 from sqlite3 import PARSE_COLNAMES, ProgrammingError
 from types import TracebackType
-from typing import Any, AsyncGenerator, Dict, List, Optional, Set
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Set, Union
 from urllib.parse import urlsplit
 from uuid import uuid4
 
@@ -143,7 +143,13 @@ class Connection(ConnectionABC):
 
 
 class Backend(BackendABC):
-    def __init__(self, url: str, type_converters: TypeConverters) -> None:
+    def __init__(
+        self,
+        url: str,
+        type_converters: TypeConverters,
+        password: Union[str, Callable[[], str], None] = None,
+    ) -> None:
+        _ = password
         _, _, path, *_ = urlsplit(url)
         self._path = path[1:]
         self._connections: Set[aiosqlite.Connection] = set()

--- a/src/quart_db/backends/asyncpg.py
+++ b/src/quart_db/backends/asyncpg.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from types import TracebackType
-from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
 
 import asyncpg
 from buildpg import BuildError, render
@@ -149,14 +149,15 @@ class Connection(ConnectionABC):
 
 
 class Backend(BackendABC):
-    def __init__(self, url: str, type_converters: TypeConverters) -> None:
+    def __init__(self, url: str, type_converters: TypeConverters, password: str | Callable[[], str] | None = None) -> None:
         self._pool: Optional[asyncpg.Pool] = None
         self._url = url
         self._type_converters = {**DEFAULT_TYPE_CONVERTERS, **type_converters}  # type: ignore
+        self._password = password
 
     async def connect(self) -> None:
         if self._pool is None:
-            self._pool = await asyncpg.create_pool(dsn=self._url, init=self._init)
+            self._pool = await asyncpg.create_pool(dsn=self._url, init=self._init, password=self._password)
 
     async def disconnect(self, timeout: Optional[int] = None) -> None:
         if self._pool is not None:

--- a/src/quart_db/backends/asyncpg.py
+++ b/src/quart_db/backends/asyncpg.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from types import TracebackType
-from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple, Union
 
 import asyncpg
 from buildpg import BuildError, render
@@ -149,7 +149,12 @@ class Connection(ConnectionABC):
 
 
 class Backend(BackendABC):
-    def __init__(self, url: str, type_converters: TypeConverters, password: str | Callable[[], str] | None = None) -> None:
+    def __init__(
+        self,
+        url: str,
+        type_converters: TypeConverters,
+        password: Union[str, Callable[[], str], None] = None,
+    ) -> None:
         self._pool: Optional[asyncpg.Pool] = None
         self._url = url
         self._type_converters = {**DEFAULT_TYPE_CONVERTERS, **type_converters}  # type: ignore
@@ -157,7 +162,9 @@ class Backend(BackendABC):
 
     async def connect(self) -> None:
         if self._pool is None:
-            self._pool = await asyncpg.create_pool(dsn=self._url, init=self._init, password=self._password)
+            self._pool = await asyncpg.create_pool(
+                dsn=self._url, init=self._init, password=self._password
+            )
 
     async def disconnect(self, timeout: Optional[int] = None) -> None:
         if self._pool is not None:

--- a/src/quart_db/extension.py
+++ b/src/quart_db/extension.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Callable, Optional, Type
+from typing import AsyncIterator, Callable, Optional, Type, Union
 from urllib.parse import urlsplit
 
 import click
@@ -67,7 +67,7 @@ class QuartDB:
         migrations_folder: Optional[str] = "migrations",
         data_path: Optional[str] = None,
         auto_request_connection: bool = True,
-        password: str | Callable[[], str] | None = None,
+        password: Union[str, Callable[[], str], None] = None,
     ) -> None:
         self._close_timeout = 5  # Seconds
         self._url = url
@@ -216,7 +216,7 @@ class QuartDB:
             if self._testing:
                 return TestingBackend(self._url, self._type_converters)
             else:
-                return Backend(self._url, self._type_converters)
+                return Backend(self._url, self._type_converters, self._password)
         else:
             raise ValueError(f"{scheme} is not a supported backend")
 

--- a/src/quart_db/extension.py
+++ b/src/quart_db/extension.py
@@ -51,6 +51,12 @@ class QuartDB:
              root path. Can be None.
         auto_request_connection: If True (the default) a connection
              is acquired and placed on g for each request.
+        password: Optional password to be used for authentication, if
+             the server requires one.
+             Password may be either a string, or a callable that
+             returns a string. If a callable is provided, it will be
+             called each time a new connection is established.
+
     """
 
     def __init__(
@@ -61,6 +67,7 @@ class QuartDB:
         migrations_folder: Optional[str] = "migrations",
         data_path: Optional[str] = None,
         auto_request_connection: bool = True,
+        password: str | Callable[[], str] | None = None,
     ) -> None:
         self._close_timeout = 5  # Seconds
         self._url = url
@@ -69,6 +76,7 @@ class QuartDB:
         self._migrations_folder = migrations_folder
         self._data_path = data_path
         self._auto_request_connection = auto_request_connection
+        self._password = password
         if app is not None:
             self.init_app(app)
 
@@ -201,7 +209,7 @@ class QuartDB:
             if self._testing:
                 return TestingBackend(self._url, self._type_converters)
             else:
-                return Backend(self._url, self._type_converters)
+                return Backend(self._url, self._type_converters, self._password)
         elif scheme == "sqlite":
             from .backends.aiosqlite import Backend, TestingBackend  # type: ignore
 

--- a/src/quart_db/interfaces.py
+++ b/src/quart_db/interfaces.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from types import TracebackType
-from typing import Any, AsyncGenerator, Callable, Dict, List, Mapping, Optional, Tuple, Type
+from typing import Any, AsyncGenerator, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union
 
 RecordType = Mapping[str, Any]
 TypeConverters = Dict[str, Dict[str, Tuple[Callable, Callable, Optional[Type]]]]
@@ -123,7 +123,12 @@ class ConnectionABC(ABC):
 
 class BackendABC(ABC):
     @abstractmethod
-    def __init__(self, url: str, type_converters: TypeConverters) -> None:
+    def __init__(
+        self,
+        url: str,
+        type_converters: TypeConverters,
+        password: Union[str, Callable[[], str], None],
+    ) -> None:
         pass
 
     @abstractmethod


### PR DESCRIPTION
The following has been true since asyncpg v0.5.1 (in 2016):
- `password: str` has been a parameter to `connect(...)`,
- Extra `**kwargs` from `Pool(...)` have been passed down to `connect(...)`
- `create_pool` has passed extra `**kwargs` through to `Pool.__init__`

Around v0.21.0 (in 2020), `password` was altered to be a `Callable` as well, which permits dynamic password lookup on connection attempt. When combined with HashiCorp vault or AWS SSM, this would permit password rotation in environments where redeploying would be undesirable.

Since the `password: str` kwarg has been around for so long, even if someone is running a particularly old version of asyncpg, this additional parameter is unlikely to break anything, but if you'd like I can add some empty-dict indirection to not even pass the kwarg if it's `None`.

(For additional context, if necessary, sqlalchemy [also supports this](https://docs.sqlalchemy.org/en/20/core/engines.html#generating-dynamic-authentication-tokens))