### PR TITLE
Add support for a psycopg backend

### DIFF
--- a/docs/how_to_guides/backends.rst
+++ b/docs/how_to_guides/backends.rst
@@ -1,10 +1,18 @@
 Database backends
 =================
 
-To connect to a postgresql database the asyncpg backend is used. It is
-installed via the ``postgresql`` extra. It will be used if
-``QUART_DB_DATABASE_URL`` has ``postgresql`` as the scheme.
+Quart-DB supports 3 backends, PostgreSQL+asyncpg, PostgreSQL+psycopg,
+and SQLite+aiosqlite. The backend used will be chosen based on the
+scheme provided in the ``QUART_DB_DATABASE_URL``. To choose
+PostgreSQL+asyncpg
 
-To connect to a sqlite database the aiosqlite backend is used. It is
-installed via the ``sqlite`` extra.  It will be used if
-``QUART_DB_DATABASE_URL`` has ``sqlite`` as the scheme.
+================== ========== =========
+Scheme             Database   Engine
+------------------ ---------- ---------
+postgresql+asyncpg PostgreSQL asyncpg
+postgresql+psycopg PostgreSQL psycopg
+sqlite             SQLite     aiosqlite
+================== ========== =========
+
+Note that ``postgresql`` as the scheme will default to
+PostgreSQL+asyncpg.

--- a/docs/how_to_guides/type_conversion.rst
+++ b/docs/how_to_guides/type_conversion.rst
@@ -2,16 +2,15 @@ Convert between Python and Postgres types
 =========================================
 
 By default Quart-DB uses the default converters whilst ensuring that
-JSON is converted, using the stdlib ``json.loads`` and ``json.dumps``
-functions if required. Custom type converters are supported, but
-depend on the DB backend used.
+JSON is converted to and from ``dict``s using the stdlib
+``json.loads`` and ``json.dumps`` functions. Custom type converters
+are supported, but depend on the DB backend used.
 
 Postgres - asyncpg
 ------------------
 
-To define a custom type converter (also called codecs) can be
-specified the ``set_converter`` method can be used. For example for
-enums:
+A custom type converter (also called codecs) can be specified the
+``set_converter`` method can be used. For example for enums:
 
 .. code-block:: python
 
@@ -25,6 +24,24 @@ enums:
 
 The keyword argument ``schema`` can be used to specify the schema to
 which the typename belongs.
+
+Postgres - psycopg
+------------------
+
+A custom type converter (also called adapter) can be specified the
+``set_converter`` method can be used. For example for enums:
+
+.. code-block:: python
+
+    from enum import Enum
+
+    class Options(Enum):
+        A = "A"
+        B = "B"
+
+    db.set_converter("options_t", lambda type_: type_.value, Options)
+
+The keyword argument ``schema`` has no affect.
 
 SQLite - aiosqlite
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ aiosqlite = ">=0.17.0"
 asyncpg = ">=0.25.0"
 buildpg = ">=0.4"
 eralchemy2 = { version = ">=1.3.2", optional = true }
+psycopg = { version = ">=3.2", optional = true, extras = ["pool"] }
 psycopg2 = { version = ">=2.9.3", optional = true }
 pydata_sphinx_theme = { version = "*", optional = true }
 python = ">=3.8"
@@ -75,9 +76,10 @@ typing_extensions = { version = "*", python = "<3.11" }
 tox = "*"
 
 [tool.poetry.extras]
-sqlite = ["aiosqlite"]
 docs = ["pydata_sphinx_theme"]
 erdiagram = ["eralchemy2", "psycopg2"]
+psycopg = ["psycopg"]
+sqlite = ["aiosqlite"]
 
 [tool.pytest.ini_options]
 addopts = "--no-cov-on-fail --showlocals --strict-markers"

--- a/src/quart_db/backends/psycopg.py
+++ b/src/quart_db/backends/psycopg.py
@@ -1,0 +1,261 @@
+import asyncio
+import json
+from types import TracebackType
+from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
+
+import asyncpg
+import psycopg
+from buildpg import BuildError, render
+from psycopg.adapt import Dumper, Loader
+from psycopg.rows import dict_row
+from psycopg.types import TypeInfo
+from psycopg_pool import AsyncConnectionPool
+
+from ..interfaces import (
+    BackendABC,
+    ConnectionABC,
+    RecordType,
+    TransactionABC,
+    TypeConverters,
+    UndefinedParameterError,
+)
+
+try:
+    from typing import LiteralString
+except ImportError:
+    from typing_extensions import LiteralString
+
+DEFAULT_TYPE_CONVERTERS = {
+    "pg_catalog": {
+        "json": (json.dumps, json.loads, dict),
+        "jsonb": (json.dumps, json.loads, dict),
+    }
+}
+
+
+class Transaction(TransactionABC):
+    def __init__(self, connection: "Connection", *, force_rollback: bool = False) -> None:
+        self._connection = connection
+        self._transaction: Optional[psycopg.AsyncTransaction] = None
+        self._force_rollback = force_rollback
+
+    async def __aenter__(self) -> "Transaction":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type: type, exc_value: BaseException, tb: TracebackType) -> None:
+        if self._force_rollback or exc_type is not None:
+            await self.rollback()
+        else:
+            await self.commit()
+
+    async def start(self) -> None:
+        self._transaction = psycopg.AsyncTransaction(self._connection._connection)
+        await self._connection._connection.wait(self._transaction._enter_gen())
+
+    async def commit(self) -> None:
+        await self._connection._connection.wait(self._transaction._exit_gen(None, None, None))
+        self._transaction = None
+
+    async def rollback(self) -> None:
+        self._transaction.force_rollback = True
+        await self._connection._connection.wait(self._transaction._exit_gen(None, None, None))
+        self._transaction = None
+
+
+class Connection(ConnectionABC):
+    supports_for_update = True
+
+    def __init__(self, connection: psycopg.AsyncConnection) -> None:
+        self._connection = connection
+
+    async def execute(self, query: LiteralString, values: Optional[Dict[str, Any]] = None) -> None:
+        compiled_query, args = self._compile(query, values)
+        try:
+            async with self._connection.cursor() as cursor:
+                await cursor.execute(compiled_query, args)
+        except psycopg.ProgrammingError as error:
+            raise UndefinedParameterError(str(error))
+
+    async def execute_many(self, query: LiteralString, values: List[Dict[str, Any]]) -> None:
+        if not values:
+            return
+
+        compiled_queries = [self._compile(query, value) for value in values]
+        compiled_query = compiled_queries[0][0]
+        args = [query[1] for query in compiled_queries]
+        try:
+            async with self._connection.cursor() as cursor:
+                return await cursor.executemany(compiled_query, args)
+        except psycopg.ProgrammingError as error:
+            raise UndefinedParameterError(str(error))
+
+    async def fetch_all(
+        self,
+        query: LiteralString,
+        values: Optional[Dict[str, Any]] = None,
+    ) -> List[RecordType]:
+        compiled_query, args = self._compile(query, values)
+        try:
+            async with self._connection.cursor() as cursor:
+                await cursor.execute(compiled_query, args)
+                return await cursor.fetchall()
+        except psycopg.ProgrammingError as error:
+            raise UndefinedParameterError(str(error))
+
+    async def fetch_one(
+        self,
+        query: LiteralString,
+        values: Optional[Dict[str, Any]] = None,
+    ) -> RecordType:
+        compiled_query, args = self._compile(query, values)
+        try:
+            async with self._connection.cursor() as cursor:
+                await cursor.execute(compiled_query, args)
+                return await cursor.fetchone()
+        except psycopg.ProgrammingError as error:
+            raise UndefinedParameterError(str(error))
+
+    async def fetch_val(
+        self,
+        query: LiteralString,
+        values: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        compiled_query, args = self._compile(query, values)
+        try:
+            async with self._connection.cursor() as cursor:
+                await cursor.execute(compiled_query, args)
+                result = await cursor.fetchone()
+                return next(iter(result.values()))
+        except psycopg.ProgrammingError as error:
+            raise UndefinedParameterError(str(error))
+
+    async def iterate(
+        self,
+        query: LiteralString,
+        values: Optional[Dict[str, Any]] = None,
+    ) -> AsyncGenerator[RecordType, None]:
+        compiled_query, args = self._compile(query, values)
+        async with self._connection.cursor() as cursor:
+            try:
+                async for record in cursor.stream(compiled_query, *args):
+                    yield record
+            except psycopg.ProgrammingError as error:
+                raise UndefinedParameterError(str(error))
+
+    def transaction(self, *, force_rollback: bool = False) -> "Transaction":
+        return Transaction(self, force_rollback=force_rollback)
+
+    def _compile(
+        self, query: LiteralString, values: Optional[Dict[str, Any]] = None
+    ) -> Tuple[str, List[Any]]:
+        if isinstance(values, list):
+            return query, []
+        else:
+            try:
+                return render(query, **(values or {}))
+            except BuildError as error:
+                raise UndefinedParameterError(str(error))
+
+
+class Backend(BackendABC):
+    def __init__(self, url: str, options: Dict[str, Any], type_converters: TypeConverters) -> None:
+        self._pool: Optional[asyncpg.Pool] = None
+        self._url = url
+        self._options = options
+        self._type_converters = {**DEFAULT_TYPE_CONVERTERS, **type_converters}
+
+    async def connect(self) -> None:
+        if self._pool is None:
+            self._pool = AsyncConnectionPool(
+                self._url,
+                kwargs={
+                    "autocommit": True,
+                    "cursor_factory": psycopg.AsyncRawCursor,
+                    "row_factory": dict_row,
+                },
+                **self._options,
+            )
+
+    async def disconnect(self, timeout: Optional[int] = None) -> None:
+        if self._pool is not None:
+            await asyncio.wait_for(self._pool.close(), timeout)
+        self._pool = None
+
+    async def acquire(self) -> Connection:
+        connection = await self._pool.getconn()
+        await _init_connection(connection, self._type_converters)  # type: ignore
+        return Connection(connection)
+
+    async def release(self, connection: Connection) -> None:  # type: ignore[override]
+        await self._pool.putconn(connection._connection)
+
+    async def _acquire_migration_connection(self) -> Connection:
+        psycopg_connection = await psycopg.AsyncConnection.connect(
+            self._url, autocommit=True, cursor_factory=psycopg.AsyncRawCursor, row_factory=dict_row
+        )
+        await _init_connection(psycopg_connection, DEFAULT_TYPE_CONVERTERS)  # type: ignore
+        return Connection(psycopg_connection)
+
+    async def _release_migration_connection(self, connection: Connection) -> None:  # type: ignore[override]  # noqa: E501
+        await connection._connection.close()
+
+    async def _init(self, connection: asyncpg.Connection) -> None:
+        await _init_connection(connection, self._type_converters)  # type: ignore
+
+
+class TestingBackend(BackendABC):
+    def __init__(self, url: str, options: Dict[str, Any], type_converters: TypeConverters) -> None:
+        self._url = url
+        self._options = options
+        self._type_converters = {**DEFAULT_TYPE_CONVERTERS, **type_converters}
+
+    async def connect(self) -> None:
+        self._connection = Connection(
+            await psycopg.AsyncConnection.connect(
+                self._url,
+                autocommit=True,
+                cursor_factory=psycopg.AsyncRawCursor,
+                row_factory=dict_row,
+            )
+        )
+        await _init_connection(self._connection._connection, self._type_converters)  # type: ignore
+
+    async def disconnect(self, timeout: Optional[int] = None) -> None:
+        await asyncio.wait_for(self._connection._connection.close(), timeout)
+
+    async def acquire(self) -> Connection:
+        return self._connection
+
+    async def release(self, connection: Connection) -> None:  # type: ignore[override]
+        pass
+
+    async def _acquire_migration_connection(self) -> Connection:
+        psycopg_connection = await psycopg.AsyncConnection.connect(
+            self._url, autocommit=True, cursor_factory=psycopg.AsyncRawCursor, row_factory=dict_row
+        )
+        await _init_connection(psycopg_connection, DEFAULT_TYPE_CONVERTERS)  # type: ignore
+        return Connection(psycopg_connection)
+
+    async def _release_migration_connection(self, connection: Connection) -> None:  # type: ignore[override]  # noqa: E501
+        await connection._connection.close()
+
+
+async def _init_connection(connection: psycopg.Connection, type_converters: TypeConverters) -> None:
+    for schema, converters in type_converters.items():
+        for typename, (encoder, decoder, type_) in converters.items():
+            psycopg_type = await TypeInfo.fetch(connection, typename)  # type: ignore
+            psycopg_type.register(connection)
+
+            class CustomLoader(Loader):
+                def load(self, data: bytes, decoder=decoder) -> Any:  # type: ignore
+                    return decoder(data.decode())
+
+            class CustomDumper(Dumper):
+                oid = psycopg_type.oid
+
+                def dump(self, elem: Any, encoder=encoder) -> bytes:  # type: ignore
+                    return encoder(elem).encode()
+
+            connection.adapters.register_loader(psycopg_type.oid, CustomLoader)
+            connection.adapters.register_dumper(type_, CustomDumper)

--- a/src/quart_db/extension.py
+++ b/src/quart_db/extension.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Dict, Optional, Type
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 import click
 from quart import g, Quart
@@ -225,23 +225,25 @@ class QuartDB:
         self._type_converters[schema][typename] = (encoder, decoder, pytype)
 
     def _create_backend(self) -> BackendABC:
-        scheme, *_ = urlsplit(self._url)
-        if scheme in {"postgresql", "postgres"}:
-            from .backends.asyncpg import Backend, TestingBackend
-
-            if self._testing:
-                return TestingBackend(self._url, self._backend_options, self._type_converters)
+        scheme, *parts = urlsplit(self._url)
+        if scheme.startswith(("postgresql", "postgres")):
+            if scheme.endswith("psycopg"):
+                from .backends.psycopg import Backend, TestingBackend
             else:
-                return Backend(self._url, self._backend_options, self._type_converters)
+                from .backends.asyncpg import Backend, TestingBackend  # type: ignore
+            scheme = "postgresql"
+            url = urlunsplit((scheme, *parts))
         elif scheme == "sqlite":
             from .backends.aiosqlite import Backend, TestingBackend  # type: ignore
 
-            if self._testing:
-                return TestingBackend(self._url, self._backend_options, self._type_converters)
-            else:
-                return Backend(self._url, self._backend_options, self._type_converters)
+            url = self._url
         else:
             raise ValueError(f"{scheme} is not a supported backend")
+
+        if self._testing:
+            return TestingBackend(url, self._backend_options, self._type_converters)
+        else:
+            return Backend(url, self._backend_options, self._type_converters)
 
 
 @click.command("db-schema")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from typing import AsyncGenerator
+from urllib.parse import urlsplit, urlunsplit
 
 import pytest
 from quart import Quart
@@ -9,10 +10,12 @@ from quart_db import Connection, QuartDB
 from .utils import Options
 
 
-@pytest.fixture(name="url", params=["aiosqlite", "asyncpg"])
+@pytest.fixture(name="url", params=["aiosqlite", "asyncpg", "psycopg"])
 def _url(request: pytest.FixtureRequest, tmp_path: Path) -> str:
-    if request.param == "asyncpg":
-        return os.environ["DATABASE_URL"]
+    if request.param in ("asyncpg", "psycopg"):
+        scheme, *parts = urlsplit(os.environ["DATABASE_URL"])
+        scheme = f"postgresql+{request.param}"
+        return urlunsplit((scheme, *parts))
     else:
         db_path = tmp_path / "temp.sql"
         return f"sqlite:////{db_path}"

--- a/tests/migrations/0.py
+++ b/tests/migrations/0.py
@@ -8,7 +8,8 @@ async def migrate(connection: Connection) -> None:
         await connection.execute(
             """CREATE TABLE tbl (
                    id INTEGER PRIMARY KEY,
-                   data JSON
+                   data JSON,
+                   value INTEGER
             )"""
         )
     else:
@@ -18,6 +19,7 @@ async def migrate(connection: Connection) -> None:
             """CREATE TABLE tbl (
                    id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
                    data JSON,
+                   value INT,
                    options OPTIONS_T
             )"""
         )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,20 +9,20 @@ async def test_execute(connection: Connection) -> None:
 
 async def test_execute_many(connection: Connection) -> None:
     await connection.execute_many(
-        "INSERT INTO tbl (data) VALUES (:data)",
-        [{"data": 2}, {"data": 3}],
+        "INSERT INTO tbl (value) VALUES (:value)",
+        [{"value": 2}, {"value": 3}],
     )
-    results = await connection.fetch_all("SELECT data FROM tbl")
-    assert [2, 3] == [result["data"] for result in results]
+    results = await connection.fetch_all("SELECT value FROM tbl")
+    assert [2, 3] == [result["value"] for result in results]
 
 
 async def test_fetch_one(connection: Connection) -> None:
     await connection.execute(
-        "INSERT INTO tbl (data) VALUES (:data)",
-        {"data": 2},
+        "INSERT INTO tbl (value) VALUES (:value)",
+        {"value": 2},
     )
     result = await connection.fetch_one("SELECT * FROM tbl")
-    assert result["data"] == 2
+    assert result["value"] == 2
 
 
 async def test_fetch_val(connection: Connection) -> None:
@@ -32,10 +32,12 @@ async def test_fetch_val(connection: Connection) -> None:
 
 async def test_iterate(connection: Connection) -> None:
     await connection.execute_many(
-        "INSERT INTO tbl (data) VALUES (:data)",
-        [{"data": 2}, {"data": 3}],
+        "INSERT INTO tbl (value) VALUES (:value)",
+        [{"value": 2}, {"value": 3}],
     )
-    assert [2, 3] == [result["data"] async for result in connection.iterate("SELECT data FROM tbl")]
+    assert [2, 3] == [
+        result["value"] async for result in connection.iterate("SELECT value FROM tbl")
+    ]
 
 
 async def test_transaction(connection: Connection) -> None:
@@ -46,7 +48,7 @@ async def test_transaction(connection: Connection) -> None:
 async def test_transaction_rollback(connection: Connection) -> None:
     try:
         async with connection.transaction():
-            await connection.execute("INSERT INTO tbl (data) VALUES (:data)", {"data": 2})
+            await connection.execute("INSERT INTO tbl (value) VALUES (:value)", {"value": 2})
             raise Exception()
     except Exception:
         pass

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -9,6 +9,10 @@ from .utils import Options
 
 @pytest.mark.skipif(sqlite3.sqlite_version < "3.35.0", reason="Requires SQLite 3.35 for RETURNING")
 async def test_json_conversion(connection: Connection) -> None:
+    id_ = await connection.fetch_val("INSERT INTO tbl (data) VALUES ('{\"a\": 2}') RETURNING id")
+    data = await connection.fetch_val("SELECT data FROM tbl WHERE id = :id", {"id": id_})
+    assert data == {"a": 2}
+
     id_ = await connection.fetch_val(
         "INSERT INTO tbl (data) VALUES (:data) RETURNING id",
         {"data": {"a": 1}},

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     aiosqlite
     asyncpg
     buildpg
+    psycopg[pool]
     pytest
     pytest-asyncio
     pytest-cov
@@ -21,6 +22,7 @@ deps =
     asyncpg
     buildpg
     pydata-sphinx-theme
+    psycopg[pool]
     sphinx
 commands =
     sphinx-apidoc -e -f -o docs/reference/source/ src/quart_db/
@@ -47,6 +49,7 @@ commands = flake8 src/quart_db/ tests/
 basepython = python3.12
 deps =
     mypy
+    psycopg[pool]
     pytest
 commands =
     mypy src/quart_db/ tests/


### PR DESCRIPTION
This is the other major postgresql DB engine in Python. As I've been seeing odd behaviour with asyncpg this will be quite helpful in tracking it down.

At the time of this commit psycopg 3.2 has not been released, and hence this has been tested against the development branch of psycopg.